### PR TITLE
Callback update

### DIFF
--- a/PSUpdateApp_2/PSUpdateApp.h
+++ b/PSUpdateApp_2/PSUpdateApp.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-typedef void(^PSUpdateAppCompletionBlock)(NSError *error, BOOL success, id JSON);
+typedef BOOL(^PSUpdateAppCompletionBlock)(NSError *error, BOOL updateAvailable, BOOL skip, id JSON);
 
 typedef enum {
     DefaultStrategy = 0,

--- a/PSUpdateApp_2/PSUpdateApp.m
+++ b/PSUpdateApp_2/PSUpdateApp.m
@@ -110,22 +110,21 @@ NSLocalizedStringFromTable(key, @"PSUdateApp", nil)
              DebugLog(@"JSON response: %@", responseObject);
              
              if ( [self isNewVersion:responseObject] ) {
-                 if ( completionBlock && ![self isSkipVersion] )
-                     completionBlock(nil, YES, responseObject);
-                 else if ( ![self isSkipVersion] )
+                 BOOL skip = [self isSkipVersion];
+                 BOOL showAlert = YES;
+                 
+                 if ( completionBlock )
+                     showAlert = completionBlock(nil, YES, skip, responseObject);
+                 if ( showAlert && !skip )
                      [self showAlert];
-                 else {
-                     if ( completionBlock )
-                         completionBlock(nil, NO, responseObject);
-                 }
              } else {
                  if ( completionBlock )
-                     completionBlock(nil, NO, responseObject);
+                     completionBlock(nil, NO, NO, responseObject);
              }
          }
          failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-             if ( completionBlock && ![self isSkipVersion] )
-                 completionBlock(error, NO, nil);
+             if ( completionBlock )
+                 completionBlock(error, NO, NO, nil);
          }];
 }
 


### PR DESCRIPTION
Hi.

I think this callback will be better. Why:
1) I want get callback _always_ for detect finish of checking. For example I set flag "executing=YES" before call "detectAppVersion:" and I set flag "executing=NO" inside callback. It's flag for check that "detectAppVersion:" already running.
2) I add BOOL return value for callback. It allow you _show default dialog after callback execution_ (return YES) or create your own dialog (return NO). 

Please check this and release new version to cocoapods. Thx. 
